### PR TITLE
Add custom transformers integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Alternatively, create a file named `.env` in the current directory and set the `
 | `PROMPTLAYER_API_KEY` |  `PromptLayer` and OpenAI Chat large language models API.|
 | `QIANFAN_AK`, `QIANFAN_SK` |  `Baidu Qianfan` chat models.|
 | `YC_API_KEY` | `YandexGPT` large language models.|
+| _none_ | Local transformers pipeline using `flan-t5-small` |
 </details>
 
 <br/>

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -1,4 +1,5 @@
 from .langchain_integration import get_langchain_chat_models_info
+from . import custom
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.outputs.llm_result import LLMResult
 from langchain.schema import BaseMessage, HumanMessage, SystemMessage, AIMessage
@@ -49,6 +50,30 @@ class ClientLangChain(ClientBase):
         # Add response message to the history too
         history += [response_message]
         return response_message.content
+
+# Custom chat client using a lightweight transformers pipeline
+class ClientCustom(ClientBase):
+    """Chat model wrapper around a local transformers pipeline"""
+    def __init__(self, model_name: str = custom.MODEL_NAME):
+        self.model_name = model_name
+        self.client = custom.initialize_client(model_name)
+
+    def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
+        # Keep track of conversation history (for compatibility only)
+        history += messages
+        system_prompt = ""
+        for msg in history:
+            if isinstance(msg, SystemMessage):
+                system_prompt = msg.content
+                break
+        user_prompt = ""
+        for msg in reversed(messages):
+            if isinstance(msg, HumanMessage):
+                user_prompt = msg.content
+                break
+        response, _ = custom.test_prompt(self.client, self.model_name, system_prompt, user_prompt)
+        history.append(AIMessage(content=response))
+        return response
 
 # Chat session allows chatting against target client while maintaining state (history buffer)
 class ChatSession:

--- a/ps_fuzz/cli.py
+++ b/ps_fuzz/cli.py
@@ -37,6 +37,7 @@ def main():
         print("Available providers:")
         for provider_name, provider_info in get_langchain_chat_models_info().items():
             print(f"  {BRIGHT}{provider_name}{RESET}: {provider_info.short_doc}")
+        print(f"  {BRIGHT}custom{RESET}: Custom local transformers pipeline")
         sys.exit(0)
 
     if args.list_attacks:

--- a/ps_fuzz/custom.py
+++ b/ps_fuzz/custom.py
@@ -1,0 +1,40 @@
+from transformers import pipeline
+from loguru import logger
+
+# Sample custom LLM integration using a lightweight model
+
+MODEL_NAME = "google/flan-t5-small"
+
+
+def validate_api_keys():
+    """Custom models typically run locally and do not require API keys."""
+    return True
+
+
+def initialize_client(model_name: str):
+    """Initialize a text2text-generation pipeline for instruction-tuned models."""
+    return pipeline("text2text-generation", model=MODEL_NAME)
+
+
+def test_prompt(client, model: str, system_prompt: str, user_prompt: str):
+    """Generate a response using the provided pipeline."""
+    try:
+        prompt = f"{system_prompt}\n{user_prompt}" if system_prompt else user_prompt
+        result = client(prompt, max_new_tokens=100)
+        generated_text = result[0]["generated_text"]
+        response = generated_text.strip()
+        logger.info(f"User Prompt: {user_prompt}")
+        logger.debug(f"Generated text: {response}")
+        return response, False
+    except Exception as exc:
+        return f"Error: {exc}", True
+
+
+def validate_model(model_name: str) -> bool:
+    """Check whether the model can be loaded."""
+    try:
+        pipeline("text-generation", model=MODEL_NAME)
+        return True
+    except Exception as exc:
+        print(f"Error loading model {MODEL_NAME}: {exc}")
+        return False

--- a/ps_fuzz/interactive_mode.py
+++ b/ps_fuzz/interactive_mode.py
@@ -101,7 +101,7 @@ class FuzzerOptions:
 class TargetLLMOptions:
     @classmethod
     def show(cls, state: AppConfig):
-        models_list = get_langchain_chat_models_info().keys()
+        models_list = list(get_langchain_chat_models_info().keys()) + ['custom']
         print("Target LLM Options: Review and modify the target LLM configuration")
         print("------------------------------------------------------------------")
         result = inquirer.prompt([
@@ -124,7 +124,7 @@ class TargetLLMOptions:
 class AttackLLMOptions:
     @classmethod
     def show(cls, state: AppConfig):
-        models_list = get_langchain_chat_models_info().keys()
+        models_list = list(get_langchain_chat_models_info().keys()) + ['custom']
         print("Attack LLM Options: Review and modify the service LLM configuration used by the tool to help attack the system prompt")
         print("---------------------------------------------------------------------------------------------------------------------")
         result = inquirer.prompt([

--- a/ps_fuzz/prompt_injection_fuzzer.py
+++ b/ps_fuzz/prompt_injection_fuzzer.py
@@ -155,7 +155,10 @@ def run_interactive_chat(app_config: AppConfig):
     app_config.print_as_table()
     target_system_prompt = app_config.system_prompt
     try:
-        target_client = ClientLangChain(app_config.target_provider, model=app_config.target_model, temperature=0)
+        if app_config.target_provider == "custom":
+            target_client = ClientCustom(app_config.target_model)
+        else:
+            target_client = ClientLangChain(app_config.target_provider, model=app_config.target_model, temperature=0)
         interactive_chat(client=target_client, system_prompts=[target_system_prompt])
     except (ModuleNotFoundError, ValidationError) as e:
         logger.warning(f"Error accessing the Target LLM provider {app_config.target_provider} with model '{app_config.target_model}': {colorama.Fore.RED}{e}{colorama.Style.RESET_ALL}")
@@ -167,15 +170,22 @@ def run_fuzzer(app_config: AppConfig):
     custom_benchmark = app_config.custom_benchmark
     target_system_prompt = app_config.system_prompt
     try:
-        target_client = ClientLangChain(app_config.target_provider, model=app_config.target_model, temperature=0)
+        if app_config.target_provider == "custom":
+            target_client = ClientCustom(app_config.target_model)
+        else:
+            target_client = ClientLangChain(app_config.target_provider, model=app_config.target_model, temperature=0)
     except (ModuleNotFoundError, ValidationError) as e:
         logger.warning(f"Error accessing the Target LLM provider {app_config.target_provider} with model '{app_config.target_model}': {colorama.Fore.RED}{e}{colorama.Style.RESET_ALL}")
         return
     client_config = ClientConfig(target_client, [target_system_prompt], custom_benchmark=custom_benchmark)
 
     try:
+        if app_config.attack_provider == "custom":
+            attack_client = ClientCustom(app_config.attack_model)
+        else:
+            attack_client = ClientLangChain(app_config.attack_provider, model=app_config.attack_model, temperature=app_config.attack_temperature)
         attack_config = AttackConfig(
-            attack_client = ClientLangChain(app_config.attack_provider, model=app_config.attack_model, temperature=app_config.attack_temperature),
+            attack_client = attack_client,
             attack_prompts_count = app_config.num_attempts
         )
     except (ModuleNotFoundError, ValidationError) as e:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup(
         "pandas==2.2.2",
         "inquirer==3.2.4",
         "prompt-toolkit==3.0.43",
-        "fastparquet==2024.2.0"
+        "fastparquet==2024.2.0",
+        "transformers==4.38.2",
+        "loguru==0.7.2"
     ],
     extras_require={
         "dev": ["pytest==7.4.4"]


### PR DESCRIPTION
## Summary
- support local transformers pipeline via new `custom` client
- list custom client in CLI provider list
- allow selecting `custom` provider in interactive mode
- handle custom provider in fuzzing/interactive flows
- add lightweight `flan-t5-small` pipeline implementation
- document local provider and update dependencies

## Testing
- `pip install transformers==4.38.2 loguru==0.7.2 --quiet`
- `pip install -e . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485213a50483329cd15fa2d9cadf41